### PR TITLE
Create Directory before writing reports

### DIFF
--- a/src/dotnet-reqube/Program.cs
+++ b/src/dotnet-reqube/Program.cs
@@ -40,13 +40,7 @@ namespace ReQube
 
                 foreach (var sonarQubeReport in sonarQubeReports)
                 {
-                    var projectDirectory = CombineOutputPath(options, sonarQubeReport.ProjectName);
-                    if (!Directory.Exists(projectDirectory))
-                    {
-                        Directory.CreateDirectory(projectDirectory);
-                    }
-
-                    var filePath = Path.Combine(projectDirectory, options.Output);
+                    var filePath = CombineOutputPath(options, Path.Combine(sonarQubeReport.ProjectName, options.Output));
 
                     WriteReport(filePath, sonarQubeReport);
                 }
@@ -71,6 +65,12 @@ namespace ReQube
         private static void WriteReport(string filePath, SonarQubeReport sonarQubeReport)
         {
             Console.WriteLine("Writing output files {0}", filePath);
+
+            var projectDirectory = Path.GetDirectoryName(filePath);
+            if (projectDirectory != null && !Directory.Exists(projectDirectory))
+            {
+                Directory.CreateDirectory(projectDirectory);
+            }
 
             File.WriteAllText(filePath, JsonConvert.SerializeObject(sonarQubeReport, JsonSerializerSettings));
         }


### PR DESCRIPTION
Hi Oleg,

we recently started to use your reqube tool in our build environment.

I encountered some DirectoryNotFoundExceptions when we had projects without any ReSharper issues in the xml. After looking into the sources, I noticed that you actively create a directory only in cases of reports with content, but rely on existing directories in other cases, which lead to the exceptions in our case.

This pull request should fix this issue. Would be glad, if you could merge it into the base project and release a new version to nuget!

Thanks and best regards,
Michael