### PR TITLE
Select output project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 
 ## Usage
 
+Create report for all projects in solution:
 `dotnet-reqube -i ResharperReport.xml -o SonarQubeReportFileName.json -d Path\To\Output\Directory`
+
+Create report for a single project in solution:
+`dotnet-reqube -i ReSharperReport.xml -o SonarQubeReportFileName.json -d Path\To\Output\Directory -p ProjectToReport`
 
 ## Demo
 

--- a/src/dotnet-reqube/Models/Options.cs
+++ b/src/dotnet-reqube/Models/Options.cs
@@ -16,5 +16,10 @@ namespace ReQube.Models
         [Option('d', "directory", Required = false, HelpText = "Directory where reports will be saved. Working directory will be used if not set.")]
         // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public string Directory { get; set; }
+
+        [Option('p', "project", Required = true,
+            HelpText = "Project to create SonarQube report for. If not set, a report is written for all projects found in the solution.")]
+        // ReSharper disable once UnusedAutoPropertyAccessor.Global
+        public string Project { get; set; }
     }
 }

--- a/src/dotnet-reqube/Models/Options.cs
+++ b/src/dotnet-reqube/Models/Options.cs
@@ -17,7 +17,7 @@ namespace ReQube.Models
         // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public string Directory { get; set; }
 
-        [Option('p', "project", Required = true,
+        [Option('p', "project", Required = false,
             HelpText = "Project to create SonarQube report for. If not set, a report is written for all projects found in the solution.")]
         // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public string Project { get; set; }

--- a/src/dotnet-reqube/Program.cs
+++ b/src/dotnet-reqube/Program.cs
@@ -36,16 +36,24 @@ namespace ReQube
                 var sonarQubeReports = Map(report);
 
                 // We need to write dummy report because SonarQube MSBuild reads a report from the root
-                WriteReport(CombineOutputPath(options, options.Output), SonarQubeReport.Empty);
-
-                foreach (var sonarQubeReport in sonarQubeReports)
+                if (string.IsNullOrEmpty(options.Project))
                 {
-                    var filePath = CombineOutputPath(options, Path.Combine(sonarQubeReport.ProjectName, options.Output));
+                    WriteReport(CombineOutputPath(options, options.Output), SonarQubeReport.Empty);
 
-                    WriteReport(filePath, sonarQubeReport);
+                    foreach (var sonarQubeReport in sonarQubeReports)
+                    {
+                        var filePath = CombineOutputPath(options, Path.Combine(sonarQubeReport.ProjectName, options.Output));
+
+                        WriteReport(filePath, sonarQubeReport);
+                    }
+
+                    TryWriteMissingReports(report.Information.Solution, options, sonarQubeReports);
                 }
-
-                TryWriteMissingReports(report.Information.Solution, options, sonarQubeReports);
+                else
+                {
+                    var projectToWrite = sonarQubeReports.FirstOrDefault(r => string.Equals(r.ProjectName, options.Project, StringComparison.OrdinalIgnoreCase));
+                    WriteReport(CombineOutputPath(options, options.Output), projectToWrite ?? SonarQubeReport.Empty);
+                }
             }
             catch (Exception e)
             {

--- a/src/dotnet-reqube/Program.cs
+++ b/src/dotnet-reqube/Program.cs
@@ -52,6 +52,10 @@ namespace ReQube
                 else
                 {
                     var projectToWrite = sonarQubeReports.FirstOrDefault(r => string.Equals(r.ProjectName, options.Project, StringComparison.OrdinalIgnoreCase));
+                    if (projectToWrite == null)
+                    {
+                        Console.WriteLine("Project " + options.Project + " not found or it contains no issues.");
+                    }
                     WriteReport(CombineOutputPath(options, options.Output), projectToWrite ?? SonarQubeReport.Empty);
                 }
             }

--- a/src/dotnet-reqube/Program.cs
+++ b/src/dotnet-reqube/Program.cs
@@ -40,13 +40,7 @@ namespace ReQube
 
                 foreach (var sonarQubeReport in sonarQubeReports)
                 {
-                    var projectDirectory = CombineOutputPath(options, sonarQubeReport.ProjectName);
-                    if (!Directory.Exists(projectDirectory))
-                    {
-                        Directory.CreateDirectory(projectDirectory);
-                    }
-
-                    var filePath = Path.Combine(projectDirectory, options.Output);
+                    var filePath = CombineOutputPath(options, Path.Combine(sonarQubeReport.ProjectName, options.Output));
 
                     WriteReport(filePath, sonarQubeReport);
                 }
@@ -71,6 +65,12 @@ namespace ReQube
         private static void WriteReport(string filePath, SonarQubeReport sonarQubeReport)
         {
             Console.WriteLine("Writing output files {0}", filePath);
+
+            var projectDirectory = Path.GetDirectoryName(filePath);
+            if (projectDirectory != null && !Directory.Exists(projectDirectory))
+            {
+                Directory.CreateDirectory(projectDirectory);
+            }
 
             File.WriteAllText(filePath, JsonConvert.SerializeObject(sonarQubeReport, JsonSerializerSettings));
         }


### PR DESCRIPTION
And another PR from me...

In our build chain, we run ReSharper inspect only on a specific project of the solution, so it would be cool if we had the same "select a project" feature in reqube because we don't really care about the numerous (empty) reports for the other projects.

This PR implements this feature by introducing an additional '-p' command line option which let's the user select a project to write. The report is written directly to the main output directory and all projects not matching the name filter are ignored.

Again, would be cool if you could pull this PR into the tool and release it to NuGet!

Best regards,
Michael